### PR TITLE
Validation on Fields

### DIFF
--- a/Checkout/CheckoutCard.swift
+++ b/Checkout/CheckoutCard.swift
@@ -197,6 +197,13 @@ open class CardValidation {
         
         valid = luhnCheck(numberOnly)
         
+        // If card number length is more than 8 and we are still not able to determine its type and treated that card as Unknown but luhncheck algorithm always gives wrong value and treat as valid checksum. Make it forcefully invalid based on this check so field can be highlighted red.
+        
+        if(numberOnly.characters.count >= 8 && type.rawValue == "Unknown" && valid)
+        {
+            valid = false
+        }
+        
         var formatted4 = ""
         for character in numberOnly.characters {
             if formatted4.characters.count == 4 {

--- a/Checkout/CheckoutCardUI.swift
+++ b/Checkout/CheckoutCardUI.swift
@@ -243,7 +243,15 @@ open class CardPaymentField: CheckoutPaymentFieldView, UITextFieldDelegate {
         
         let isDeleating = (string.characters.count == 0 && range.length == 1)
         
-        if textField == self.numberField {
+        if textField == self.numberField
+        {
+            // Since all cards in CardType Enum i.e Amex, Visa, MasterCard, Diners, Discover, JCB, Elo, Hipercard, UnionPay are not having numbers more than max length of 19 characters. 19 charachters + 4 spaces = 23 :)
+            
+            if(string.characters.count != 0 && textField.text?.characters.count == 23)
+            {
+                return false;
+            }
+            
             let (type, formatted, valid) = CardValidation.checkCardNumber(numberOnly)
             
             self.numberField.valid = valid
@@ -273,6 +281,12 @@ open class CardPaymentField: CheckoutPaymentFieldView, UITextFieldDelegate {
             
             self.valid = (self.numberField.valid && self.expirationField.valid && self.cvcField.valid)
             
+            // We have done all validations now make next cvv field first responder
+            if(string.characters.count != 0 && textField.text?.characters.count == 7)
+            {
+                cvcField.becomeFirstResponder()
+            }
+            
             //delegate?.fieldChangedValue(self.expirationField, valid: valid)
             delegate?.paymentFieldChangedValidity(valid)
         }
@@ -285,6 +299,11 @@ open class CardPaymentField: CheckoutPaymentFieldView, UITextFieldDelegate {
                 textField.text = newString
                 
                 self.valid = (self.numberField.valid && self.expirationField.valid && self.cvcField.valid)
+                
+                if(string.characters.count != 0 && textField.text?.characters.count == 4)
+                {
+                     UIApplication.shared.sendAction("resignFirstResponder", to:nil, from:nil, for:nil)
+                }
                 delegate?.paymentFieldChangedValidity(valid)
             }
             

--- a/Example/AdyenCheckout/Info.plist
+++ b/Example/AdyenCheckout/Info.plist
@@ -35,9 +35,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
1- Since all cards in CardType Enum i.e Amex, Visa, MasterCard, Diners, Discover, JCB, Elo, Hipercard, UnionPay are not having numbers more than max length of 19 characters so I have applied the check on number fields length

2- Once you fill the card expiry then CVV fields becomes first responder

3- Once you fill CVV (Max length 4 due to Amex) keyboard is resigned

4- Since example doesn't support these Orientation like Upside Down, Landscape Left and Landscape right so I have removed support as it really Sucks

5- If card number length is more than 8 and we are still not able to determine its type and treated that card as Unknown but luhncheck algorithm always gives wrong value and treat as valid checksum. Make it forcefully invalid based on this check so field can be highlighted red.
For example if you go for this card 9340 0000 0000 0000 luhncheck algorithm says it's valid but card is not from supported from types. It should highlight as red and says invalid.